### PR TITLE
Allow exact shorthands in the text format

### DIFF
--- a/proposals/custom-rtts/Overview.md
+++ b/proposals/custom-rtts/Overview.md
@@ -508,6 +508,9 @@ reftype :: ...
   | 0x62 ht:absheaptype => ref null exact ht
 ```
 
+Similarly, we allow combining `exact` with the established shorthands in the text format.
+For example `(exact anyref)` is a shorthand for `(ref null exact any)`.
+
 ### Instructions
 
 The existing `ref.test`, `ref.cast`, `br_on_cast` and `br_on_cast_fail` instructions


### PR DESCRIPTION
Clarify that we allow e.g. `(exact anyref)` in the text format, just
like we allow the exact prefix (0x62) to be combined with shorthands in
the binary format.
